### PR TITLE
fixed mdx_mathjax in wagtailmd for python 3.8

### DIFF
--- a/wagtail_tuto/wagtailmd/mdx/mdx_mathjax.py
+++ b/wagtail_tuto/wagtailmd/mdx/mdx_mathjax.py
@@ -1,4 +1,4 @@
-import cgi
+import html
 
 import markdown
 
@@ -12,7 +12,7 @@ class MathJaxPattern(markdown.inlinepatterns.Pattern):
     def handleMatch(self, m):
         # Pass the math code through, unmodified except for basic entity substitutions.
         # Stored in htmlStash so it doesn't get further processed by Markdown.
-        text = cgi.escape(m.group(2) + m.group(3) + m.group(2))
+        text = html.escape(m.group(2) + m.group(3) + m.group(2))
         return self.markdown.htmlStash.store(text)
 
 


### PR DESCRIPTION
escape has been removed from cgi module in python 3.8.  On their release note they say, "parse_qs, parse_qsl, and escape are removed from the cgi module. They are deprecated in Python 3.2 or older. They should be imported from the urllib.parse and html modules instead." So I replaced cgi module with html module. Then the code worked fine.