### PR TITLE
Fix removed in wagtail211 warning

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -69,7 +69,6 @@ MIDDLEWARE = [
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 
-    'wagtail.core.middleware.SiteMiddleware',
     'wagtail.contrib.redirects.middleware.RedirectMiddleware',
 ]
 

--- a/wagtail_tuto/home/views.py
+++ b/wagtail_tuto/home/views.py
@@ -5,8 +5,9 @@ from django.shortcuts import render
 
 from home.models import CopyWritingSettings
 
+from wagtail.core.models import Site
 
 def home(request):
-    social_media_setting = CopyWritingSettings.for_site(request.site)
+    social_media_setting = CopyWritingSettings.for_site(Site.find_for_request(request))
     context = {'social_media_setting': social_media_setting}
     return render(request, 'home/home_page.html', context=context)

--- a/wagtail_tuto/home/views.py
+++ b/wagtail_tuto/home/views.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals
 
 from django.shortcuts import render
 from wagtail.core.models import Site
+
 from home.models import CopyWritingSettings
 
 

--- a/wagtail_tuto/home/views.py
+++ b/wagtail_tuto/home/views.py
@@ -2,12 +2,12 @@
 from __future__ import unicode_literals
 
 from django.shortcuts import render
-
+from wagtail.core.models import Site
 from home.models import CopyWritingSettings
 
-from wagtail.core.models import Site
 
 def home(request):
-    social_media_setting = CopyWritingSettings.for_site(Site.find_for_request(request))
+    site = Site.find_for_request(request)
+    social_media_setting = CopyWritingSettings.for_site(site)
     context = {'social_media_setting': social_media_setting}
     return render(request, 'home/home_page.html', context=context)


### PR DESCRIPTION
This PR is to fix the following warning:
RemovedInWagtail211Warning: wagtail.core.middleware.SiteMiddleware and the use of request.site is deprecated. Please update your code to use Site.find_for_request(request) in place of request.site, and remove wagtail.core.middleware.SiteMiddleware from MIDDLEWARE

Thanks to @marteinn 